### PR TITLE
You may want to completely change this but...

### DIFF
--- a/api/CRM_Events_Account_Created_Policy.xml
+++ b/api/CRM_Events_Account_Created_Policy.xml
@@ -1,0 +1,17 @@
+<policies>
+    <inbound>
+        <base />
+        <set-method id="apim-generated-policy">POST</set-method>
+        <rewrite-uri id="apim-generated-policy" template="/manual/paths/invoke/?api-version=2016-06-01&amp;sp=/triggers/manual/run&amp;sv=1.0&amp;sig={{crm-events-api_manual-invoke_5ce2a58dc7f31925d3559b24}}" />
+        <set-header id="apim-generated-policy" name="Ocp-Apim-Subscription-Key" exists-action="delete" />
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/api/CRM_Events_OpenAPI.json
+++ b/api/CRM_Events_OpenAPI.json
@@ -1,0 +1,70 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "CRM Events API",
+        "version": "1.0",
+        "description": "Azure Logic App."
+    },
+    "host": "dev-api-customerengagement.platform.education.gov.uk",
+    "basePath": "/v1/crm-events",
+    "schemes": [
+        "https"
+    ],
+    "securityDefinitions": {
+        "apiKeyHeader": {
+            "type": "apiKey",
+            "name": "Ocp-Apim-Subscription-Key",
+            "in": "header"
+        },
+        "apiKeyQuery": {
+            "type": "apiKey",
+            "name": "subscription-key",
+            "in": "query"
+        }
+    },
+    "security": [
+        {
+            "apiKeyHeader": []
+        },
+        {
+            "apiKeyQuery": []
+        }
+    ],
+    "x-servers": [
+        {
+            "url": "https://dev-api-customerengagement.platform.education.gov.uk"
+        },
+        {
+            "url": "https://c106d01-apim-custeng-westeurope-01.regional.azure-api.net"
+        }
+    ],
+    "paths": {
+        "/account": {
+            "post": {
+                "operationId": "account-created",
+                "summary": "Account Created",
+                "parameters": [
+                    {
+                        "name": "body",
+                        "in": "body",
+                        "schema": {}
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "responses": {}
+            }
+        }
+    },
+    "definitions": {
+        "request-manual": {},
+        "ManualPathsInvokePost202ApplicationJsonResponse": {
+            "type": "object"
+        },
+        "ManualPathsInvokePost500ApplicationJsonResponse": {
+            "type": "object"
+        }
+    },
+    "tags": []
+}

--- a/api/CRM_Events_Policy.xml
+++ b/api/CRM_Events_Policy.xml
@@ -1,0 +1,15 @@
+<policies>
+    <inbound>
+        <base />
+        <set-backend-service id="apim-generated-policy" backend-id="LogicApp_s113d01-accountdisp-la-02_s113d01-dispatchers" />
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>


### PR DESCRIPTION
Here is the swagger for the CRM Events API (`CRM_Events_OpenAPI.json`), base policy (`CRM_Events_Policy.xml`) and policy for the account-created endpoint (`CRM_Events_Account_Created_Policy.xml`).

I've double checked this, it is parameterised :) No secret information included.

This may be unlike the other dispatcher, so you may wish to refactor a little. I just wanted to make sure this was included in the source, though.